### PR TITLE
 Fix use of extern in declarations, following libtool docs

### DIFF
--- a/include/libcnotify.h.in
+++ b/include/libcnotify.h.in
@@ -78,7 +78,7 @@ int libcnotify_stream_close(
 
 /* Value to indicate if the verbose notification is active
  */
-LIBCNOTIFY_EXTERN \
+LIBCNOTIFY_EXTERN_VARIABLE \
 int libcnotify_verbose;
 
 /* Sets the verbose notification

--- a/include/libcnotify/extern.h
+++ b/include/libcnotify/extern.h
@@ -33,12 +33,14 @@
 #define LIBCNOTIFY_EXTERN __declspec(dllexport)
 
 #elif defined( LIBCNOTIFY_DLL_IMPORT )
-#define LIBCNOTIFY_EXTERN extern __declspec(dllimport)
+#define LIBCNOTIFY_EXTERN __declspec(dllimport)
 
 #else
-#define LIBCNOTIFY_EXTERN extern
+#define LIBCNOTIFY_EXTERN
 
 #endif
+
+#define LIBCNOTIFY_EXTERN_VARIABLE extern LIBCNOTIFY_EXTERN
 
 #endif /* !defined( _LIBCNOTIFY_EXTERN_H ) */
 

--- a/libcnotify/libcnotify_extern.h
+++ b/libcnotify/libcnotify_extern.h
@@ -30,14 +30,8 @@
 
 #include <libcnotify/extern.h>
 
-#if defined( __CYGWIN__ ) || defined( __MINGW32__ )
-#define LIBCNOTIFY_EXTERN_VARIABLE	extern
 #else
-#define LIBCNOTIFY_EXTERN_VARIABLE	LIBCNOTIFY_EXTERN
-#endif
-
-#else
-#define LIBCNOTIFY_EXTERN		/* extern */
+#define LIBCNOTIFY_EXTERN
 #define LIBCNOTIFY_EXTERN_VARIABLE	extern
 
 #endif /* !defined( HAVE_LOCAL_LIBCNOTIFY ) */


### PR DESCRIPTION
This fixes the same problem as https://github.com/libyal/libfmapi/pull/9 for libfmapi and https://github.com/libyal/libclocale/pull/8 for libclocale.